### PR TITLE
Add `removed` method to GUIMedia.

### DIFF
--- a/src/main/java/gui/media/GUIMedia.java
+++ b/src/main/java/gui/media/GUIMedia.java
@@ -94,4 +94,14 @@ public class GUIMedia<M extends Media> extends Pane {
      * should properly represent the Media object which was passed in.
      */
     public void mediaUpdated(Media media) {}
+
+    /**
+     * This method is called when this GUIMedia object is "removed" and will
+     * no longer be displayed.
+     * <p>
+     * Implementations of this method can specify the procedure to "clean up"
+     * any resources used by an instance of GUIMedia when it is no longer
+     * visible.
+     */
+    public void removed() {}
 }

--- a/src/main/java/gui/page/Page.java
+++ b/src/main/java/gui/page/Page.java
@@ -134,6 +134,18 @@ public class Page extends StackPane implements MediaObserver {
     public void removeMedia(GUIMedia media) {
         contents.remove(media.getID());
         mediaLayer.getChildren().remove(media);
+        media.removed();
+    }
+
+    /**
+     * Remove ALL GUIMedia objects from this page.
+     */
+    public void removeAllMedia() {
+        Set<GUIMedia> mediaToRemove = new HashSet<>(contents.values());
+
+        for (GUIMedia media: mediaToRemove) {
+            removeMedia(media);
+        }
     }
 
     /**

--- a/src/main/java/gui/page_screen/PageScreen.java
+++ b/src/main/java/gui/page_screen/PageScreen.java
@@ -53,10 +53,7 @@ public class PageScreen extends VBox {
     }
 
     public void newPage(MediaCommunicator c) {
-        if (page != null) {
-            page.setEventHandler(null);
-            layers.getChildren().remove(page);
-        }
+        closePage();
 
         page = new Page(c);
         page.setEventHandler(toolBar.selectedTool().getValue());
@@ -67,5 +64,13 @@ public class PageScreen extends VBox {
         });
 
         layers.getChildren().add(0, page);
+    }
+
+    public void closePage() {
+        if (page != null) {
+            page.setEventHandler(null);
+            layers.getChildren().remove(page);
+            page.removeAllMedia();
+        }
     }
 }

--- a/src/main/java/gui/start_screen/StartScreen.java
+++ b/src/main/java/gui/start_screen/StartScreen.java
@@ -108,6 +108,7 @@ public class StartScreen extends VBox {
     }
 
     private void closePage() {
+        pageScreen.closePage();
         pageScreen = null;
         closeStorage();
         c = null;


### PR DESCRIPTION
Add a method to GUIMedia which is called when the object is removed from the page. This allows GUIMedia instances to implement clean-up functionality if they acquire any resources that don't get freed up automatically.