### PR TITLE
Add ResourceLoader utility class

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,5 +40,8 @@ jar {
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
-}
 
+    into 'res', {
+        from 'res'
+    }
+}

--- a/res/icons/pen.svg
+++ b/res/icons/pen.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="20mm"
+   height="20mm"
+   viewBox="0 0 20 20"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="pen.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="4.394379"
+     inkscape:cx="62.124819"
+     inkscape:cy="87.95327"
+     inkscape:window-width="1914"
+     inkscape:window-height="1057"
+     inkscape:window-x="900"
+     inkscape:window-y="17"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2">
+    <rect
+       x="2.2694593"
+       y="3.0539625"
+       width="104.8575"
+       height="98.76088"
+       id="rect5314" />
+  </defs>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       id="path56210"
+       style="fill:#050000;fill-opacity:1;stroke:none;stroke-width:2.16958;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke"
+       d="m 17.470826,0.01790386 c -1.273529,0.03265274 -2.51303,3.78872574 -4.157883,8.42864764 -2.155981,6.0817515 -3.9871923,7.8466735 -2.77833,9.6335395 -0.390349,0.110369 -0.6617007,0.481915 -0.6619747,0.906404 1.86e-4,0.334607 0.1698647,0.643848 0.4454507,0.811837 C 9.7771773,19.668031 2.8088459,17.296167 4.545257,15.946371 6.9340114,14.089477 8.903968,12.763315 8.5322256,10.090838 8.0807169,6.8449156 5.2072481,4.3607662 0.05270996,4.4577901 c -0.0197532,1.2769653 0.02583822,2.9823996 0.02583822,2.9823996 0,0 5.35342532,0.2694538 5.38501772,3.2838003 0.023138,2.207789 -2.6783521,2.787087 -3.7186549,4.734555 -1.99757067,3.739494 7.9701146,4.330933 8.611418,4.361491 0.126908,0.06929 0.267789,0.105622 0.410828,0.105937 0.494085,-2.8e-5 0.894587,-0.420659 0.894519,-0.939478 10e-6,-0.129097 -0.02532,-0.256812 -0.07441,-0.37517 2.226717,-0.420201 1.900003,-2.444789 4.313883,-9.2540375 0.792744,-2.2362292 1.479444,-3.8518446 1.781475,-5.5008218 1.971516,1.6751048 -0.131038,6.0202793 -0.990212,8.8058453 l 1.501074,0.631372 c 0,0 4.03551,-8.8634252 0.05456,-10.7968608 0.157358,-1.3915978 -7.93e-4,-2.3048736 -0.594795,-2.45876452 -0.05909,-0.01530853 -0.119785,-0.0217596 -0.182418,-0.02015382 z"
+       sodipodi:nodetypes="sscccssccssccccsccccsss" />
+  </g>
+</svg>

--- a/res/icons/wrench.svg
+++ b/res/icons/wrench.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="20mm"
+   height="20mm"
+   viewBox="0 0 20 20"
+   version="1.1"
+   id="svg5"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2">
+    <rect
+       x="2.2694593"
+       y="3.0539625"
+       width="104.8575"
+       height="98.76088"
+       id="rect5314" />
+  </defs>
+  <g
+     id="layer1">
+    <path
+       id="rect63711"
+       style="fill:#050000;fill-opacity:1;stroke:none;stroke-width:2.16959;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke"
+       d="M 16.17474,0.53560542 A 6.3474626,6.3474626 0 0 0 9.3922064,1.841663 6.3474626,6.3474626 0 0 0 8.087358,9.1693222 L 0.29906487,16.6662 c -0.36104063,0.347531 -0.37191734,0.918031 -0.0243858,1.279071 l 1.64224042,1.706077 c 0.3475317,0.36104 0.9180303,0.371917 1.279071,0.02439 l 7.8388835,-7.545573 a 6.3474626,6.3474626 0 0 0 7.161287,-1.14232 6.3474626,6.3474626 0 0 0 1.687163,-6.3627731 L 15.565798,8.7810487 C 15.100432,9.2290018 14.365263,9.215328 13.91731,8.7499621 L 11.707506,6.4542545 C 11.259553,5.9888889 11.273575,5.2533838 11.738947,4.8054308 Z" />
+  </g>
+</svg>

--- a/src/main/java/gui/Main.java
+++ b/src/main/java/gui/Main.java
@@ -1,5 +1,7 @@
 package gui;
 
+import java.net.URL;
+
 import javafx.application.*;
 import javafx.stage.*;
 import javafx.scene.*;
@@ -29,7 +31,10 @@ public class Main extends Application {
         // load it into the scene so that it gets applied to all the contents
         // of that scene.
         Scene scene = new Scene(gui);
-        scene.getStylesheets().add("file:res/css/base.css");
+
+        // Load the stylesheets
+        URL cssURL = ResourceLoader.getResourceURL("css/base.css");
+        scene.getStylesheets().add(cssURL.toString());
 
         // The stage is the main window for the application. To actually get
         // the GUI on the screen, we add the scene in which it is contained to

--- a/src/main/java/gui/ResourceLoader.java
+++ b/src/main/java/gui/ResourceLoader.java
@@ -1,0 +1,127 @@
+package gui;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.MalformedURLException;
+
+import javafx.scene.*;
+import javafx.scene.layout.*;
+import javafx.scene.shape.*;
+import javafx.scene.image.*;
+import javafx.scene.paint.*;
+
+
+/**
+ * Utility class for loading resource files (icon images, stylesheets, etc.).
+ * <p>
+ * Resource files are stored in the `res` directory. However, when the project
+ * is built as a JAR file, the res directory is included and resources should
+ * be loaded from the JAR file rather than from an external file.
+ * <p>
+ * Additionally, there is a common setup process for loading images of the same
+ * type, etc. which is implemented by this class to avoid duplication elsewhere.
+ */
+public final class ResourceLoader {
+
+    private ResourceLoader() {}
+
+    private static ClassLoader getClassLoader() {
+        return ResourceLoader.class.getClassLoader();
+    }
+
+    /**
+     * Return a URL for the resource at the given path.
+     * <p>
+     * The path is expected to be relative to the resource directory.
+     * The returned URL will either be for a file in the external `res`
+     * directory, or a JAR entry in the internal `res` directory, depending on
+     * how/where the program is run.
+     */
+    public static URL getResourceURL(String path) {
+        path = "res/" + path;
+        File resourceFile = new File(path);
+
+        if (resourceFile.exists()) {
+            try {
+                return resourceFile.toURI().toURL();
+            } catch (MalformedURLException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            return getClassLoader().getResource(path);
+        }
+    }
+
+    // Return a placeholder node with the given dimensions. If loading an icon
+    // fails, this method can be used to return a node which would take up the
+    // same amount of space as the desired icon so layouts don't get messed up.
+    //
+    // Additionally, using this method when exceptions are encountered means
+    // GUI elements don't have to explicitly handle exceptions each time they
+    // want to load an icon.
+    private static Node getPlaceholder(int width, int height) {
+        Region r = new Region();
+        r.setPrefWidth(width);
+        r.setPrefHeight(height);
+
+        return r;
+    }
+
+    /**
+     * Load an SVG image as an icon with the given dimensions and colour.
+     *
+     * @param path The path to the SVG image relative to the `res` directory.
+     */
+    public static Node loadSVGicon(String path, int width, int height, Color colour) {
+        try (InputStream s = getResourceURL(path).openStream()) {
+            // JavaFX has incomplete support for SVG images: It only supports
+            // the "path" element. Therefore, when loading an SVG file, we just
+            // look for the first path element in the file and use its contents.
+            String svgString = new String(s.readAllBytes());
+            svgString = svgString.substring(svgString.indexOf("<path") + 5);
+            svgString = svgString.substring(svgString.indexOf(" d=\"") + 4);
+            svgString = svgString.substring(0, svgString.indexOf('"'));
+
+            SVGPath svgPath = new SVGPath();
+            svgPath.setContent(svgString);
+
+            Region svgRegion = new Region();
+            svgRegion.setShape(svgPath);
+            svgRegion.setPrefWidth(width);
+            svgRegion.setPrefHeight(height);
+            svgRegion.setMaxWidth(width);
+            svgRegion.setMaxHeight(height);
+            svgRegion.setBackground(Background.fill(colour));
+
+            return svgRegion;
+        } catch (Exception e) {
+            return getPlaceholder(width, height);
+        }
+    }
+
+    public static Node loadSVGicon(String path, int width, int height) {
+        return loadSVGicon(path, width, height, Color.BLACK);
+    }
+
+    /**
+     * Load a bitmap image as an icon with the given dimensions and colour.
+     * <p>
+     * The formats supported by JavaFX are: BMP, GIF, JPEG and PNG.
+     *
+     * @param path The path to the bitmap image relative to the `res` directory.
+     */
+    public static Node loadBitmapIcon(String path, int width, int height) {
+        try (InputStream s = getResourceURL(path).openStream()) {
+            Image image = new Image(s);
+            ImageView view = new ImageView(image);
+
+            view.setFitWidth(width);
+            view.setFitHeight(height);
+
+            return view;
+        } catch (Exception e) {
+            return getPlaceholder(width, height);
+        }
+    }
+}

--- a/src/main/java/gui/page_screen/ToolPane.java
+++ b/src/main/java/gui/page_screen/ToolPane.java
@@ -6,9 +6,11 @@ import javafx.scene.*;
 import javafx.scene.layout.*;
 import javafx.scene.control.*;
 import javafx.scene.text.*;
+import javafx.scene.paint.*;
 import javafx.geometry.*;
 import javafx.beans.value.*;
 
+import gui.ResourceLoader;
 import gui.tool.Tool;
 
 
@@ -139,7 +141,7 @@ class ToolPaneTitleBar extends HBox {
     private Text titleText;
 
     public ToolPaneTitleBar(Node... contents) {
-        super(PADDING);
+        super(PADDING * 2);
 
         titleText = new Text();
 
@@ -149,7 +151,9 @@ class ToolPaneTitleBar extends HBox {
         Region spacer = new Region();
         HBox.setHgrow(spacer, Priority.ALWAYS);
 
-        getChildren().addAll(titleText, spacer);
+        Node icon = ResourceLoader.loadSVGicon("icons/wrench.svg", 12, 12, Color.GRAY);
+
+        getChildren().addAll(icon, titleText, spacer);
         getChildren().addAll(contents);
     }
 

--- a/src/main/java/gui/tool/PenTool.java
+++ b/src/main/java/gui/tool/PenTool.java
@@ -1,5 +1,6 @@
 package gui.tool;
 
+import javafx.scene.*;
 import javafx.scene.input.*;
 import javafx.scene.control.*;
 import javafx.scene.layout.*;
@@ -8,6 +9,7 @@ import javafx.scene.paint.*;
 import javafx.geometry.*;
 import javafx.beans.property.*;
 
+import gui.ResourceLoader;
 import gui.page.PageEventHandler.*;
 import gui.page.Page;
 import gui.media.GUIPenStroke;
@@ -37,6 +39,12 @@ public class PenTool implements Tool {
     @Override
     public String getName() {
         return "Pen";
+    }
+
+    @Override
+    public Node getGraphic() {
+        return new Label(
+                getName(), ResourceLoader.loadSVGicon("icons/pen.svg", 15, 15));
     }
 
     @Override

--- a/src/test/java/TestResourceLoader.java
+++ b/src/test/java/TestResourceLoader.java
@@ -1,0 +1,37 @@
+import org.junit.*;
+import static org.junit.Assert.*;
+
+import javafx.scene.*;
+import javafx.scene.layout.*;
+
+import gui.ResourceLoader;
+
+
+public class TestResourceLoader {
+
+    @Test
+    public void testLoadNonExistantIcon() {
+        // Loading a non-existant icon should not cause any error and should 
+        // return a placeholder region with the requested size.
+
+        // pick arbitrary values to make sure they are preserved in the returned
+        // placeholder icon.
+        final int SVG_WIDTH = 61;
+        final int SVG_HEIGHT = 13;
+
+        final int BITMAP_WIDTH = 11;
+        final int BITMAP_HEIGHT = 42;
+
+        Node nonExistantSVG = ResourceLoader.loadSVGicon("this path does not exist", SVG_WIDTH, SVG_HEIGHT);
+        Node nonExistantBitmap = ResourceLoader.loadBitmapIcon("this path does not exist", BITMAP_WIDTH, BITMAP_HEIGHT);
+
+        assertTrue(nonExistantSVG instanceof Region);
+        assertTrue(nonExistantBitmap instanceof Region);
+
+        Region SVGRegion = (Region) nonExistantSVG;
+        Region bitmapRegion = (Region) nonExistantBitmap;
+
+        assertTrue(SVGRegion.getPrefWidth() == SVG_WIDTH && SVGRegion.getPrefHeight() == SVG_HEIGHT);
+        assertTrue(bitmapRegion.getPrefWidth() == BITMAP_WIDTH && bitmapRegion.getPrefHeight() == BITMAP_HEIGHT);
+    }
+}


### PR DESCRIPTION
The project currently stores fonts, images, etc. in the `res` directory and just loads them by path, but this won't work if we want to build the project into a JAR file so we can just give it to someone to run.

I modified build.gradle to add the `res` directory to the JAR file and added the ResourceLoader utility class to provide methods which load resources either from the external `res` directory or from inside the current JAR file, depending on what is available.

I changed loading the stylesheets in `gui.Main` from using a hard-coded path to using the ResourceLoader class.

Additionally, I added helper methods for loading icon images in the ResourceLoader and used them to add icons to the pen tool's toolbar button and to the tool settings pane.