### PR TITLE
Fix: Set GUIMedia to use unmanaged layout

### DIFF
--- a/src/main/java/gui/media/GUIMedia.java
+++ b/src/main/java/gui/media/GUIMedia.java
@@ -31,6 +31,9 @@ public class GUIMedia<M extends Media> extends Pane {
 
         // Don't block mouse clicks/other input
         setPickOnBounds(false);
+        // Don't use a managed layout, i.e. stop the page in which the GUIMedia
+        // is placed from influencing the layout bounds of the GUIMedia.
+        setManaged(false);
 
         width = new SimpleDoubleProperty();
         height = new SimpleDoubleProperty();


### PR DESCRIPTION
This resolves an issue where the reported size of GUIMedia objects is larger than the actual size of their contents.