### PR TITLE
Make MediaCommunicator generate new IDs on its own

### DIFF
--- a/src/main/java/gui/page/Page.java
+++ b/src/main/java/gui/page/Page.java
@@ -116,12 +116,7 @@ public class Page extends StackPane implements MediaObserver {
      */
     public void updateMedia(GUIMedia media) {
         try {
-            if (media.getID() == Media.EMPTY_ID) {
-                media.getMedia().setID(c.getNewID());
-            }
-
-            contents.put(media.getID(), media);
-            c.updateMedia(media.getMedia());
+            c.updateMedia(media.getMedia(), id -> contents.put(id, media));
         } catch (Exception e) {
             new ErrorWindow(this, null, "Updating Media object failed.", e)
                 .show();


### PR DESCRIPTION
Instead of having to call `getNewID()` on MediaCommunicator before calling `updateMedia`, make the MediaCommunicator generate the ID itself.

If the caller wants to do something with the ID before any MediaObservers are notified, it can supply a `Consumer<Long>` to the `updateMedia` method which will be called AFTER the ID is generated, but BEFORE any MediaObservers are notified of the change.

--

This PR should not require any changes to other parts of the program.