### PR TITLE
Removed media manger interface

### DIFF
--- a/src/main/java/app/media_managers/AudioModifier.java
+++ b/src/main/java/app/media_managers/AudioModifier.java
@@ -1,29 +1,21 @@
 package app.media_managers;
 
-import app.media_managers.MediaManager;
+public class AudioModifier  {
 
-public class AudioModifier implements MediaManager {
-
-    private String TimeStamp;
-
-    @Override
     public void addMedia() throws Exception {
 
     }
 
-    @Override
     public void modifyMedia() throws Exception{
 
     }
 
-    @Override
     public void searchMedia() {
 
     }
 
-    public void addTimeStamp(String givenTimeStamp){
+    public void addTimeStamp(){
 
-        this.TimeStamp = givenTimeStamp;
     }
 
 }

--- a/src/main/java/app/media_managers/ImageModifier.java
+++ b/src/main/java/app/media_managers/ImageModifier.java
@@ -1,23 +1,20 @@
 package app.media_managers;
 
-public class ImageModifier implements MediaManager {
-    private String caption;
-    @Override
+public class ImageModifier  {
+
     public void addMedia() throws Exception{
 
     }
 
-    @Override
     public void modifyMedia() throws Exception{
 
     }
 
-    @Override
     public void searchMedia() {
 
     }
 
-    public void addCaption(String givenCaption){
-        this.caption = givenCaption;
+    public void addCaption(){
+
     }
 }

--- a/src/main/java/app/media_managers/MediaManager.java
+++ b/src/main/java/app/media_managers/MediaManager.java
@@ -1,7 +1,0 @@
-package app.media_managers;
-
-interface MediaManager {
-    public void addMedia() throws Exception;
-    public void modifyMedia() throws Exception;
-    public void searchMedia();
-}

--- a/src/main/java/app/media_managers/TextModifier.java
+++ b/src/main/java/app/media_managers/TextModifier.java
@@ -1,26 +1,20 @@
 package app.media_managers;
 
-import app.media_managers.MediaManager;
-
-public class TextModifier implements MediaManager {
-    private String link;
-    @Override
+public class TextModifier {
     public void addMedia() throws Exception{
 
     }
 
-    @Override
     public void modifyMedia() throws Exception{
 
     }
 
-    @Override
     public void searchMedia() {
 
     }
 
-    public void addLink(String givenLink){
-        this.link = givenLink;
+    public void addLink(){
+
     }
 
 


### PR DESCRIPTION
MediaManager interface was removed as it is too restrictive in the method signatures that implementers could have. This led to some code smells to work around it such as defining instance variables to be used as effective parameters. This shouldn't negatively impact clean architecture as classes that use the MediaManagers do so with an inwards dependancy.