### PR TITLE
Add default tags + z-indices to media types

### DIFF
--- a/src/main/java/app/media/EllipseShape.java
+++ b/src/main/java/app/media/EllipseShape.java
@@ -14,6 +14,7 @@ public class EllipseShape extends GenericShape {
      */
     public EllipseShape(Point2D p1, Point2D p2, String colour) {
         super("Ellipse", p1, p2, colour);
+        getTags().add("ellipse");
     }
 
     /**

--- a/src/main/java/app/media/GenericShape.java
+++ b/src/main/java/app/media/GenericShape.java
@@ -25,6 +25,9 @@ public abstract class GenericShape extends Media {
         this.p1 = new Point(p1);
         this.p2 = new Point(p2);
         this.colour = colour;
+
+        setZindex(1);
+        getTags().add("shape");
     }
 
     private record Point(double x, double y) implements Serializable {

--- a/src/main/java/app/media/Hyperlink.java
+++ b/src/main/java/app/media/Hyperlink.java
@@ -7,6 +7,13 @@ public class Hyperlink extends MediaText {
     public Hyperlink(double x, double y, String text, String link, String colour){
         super(x, y, text, colour);
         this.link = link;
+
+        getTags().add("URL");
+        getTags().add("url");
+        getTags().add("hyperlink");
+        getTags().add("link");
+
+        setZindex(-1);
     }
 
     public void setLink(String link){

--- a/src/main/java/app/media/MediaAudio.java
+++ b/src/main/java/app/media/MediaAudio.java
@@ -17,6 +17,7 @@ public class MediaAudio extends FileMedia{
                       ArrayList<Duration>  timestamps) {
         super(name, x, y, width, height, rawData);
         this.timestamps = timestamps;
+        setDefaultTags();
     }
 
 
@@ -24,4 +25,7 @@ public class MediaAudio extends FileMedia{
         return timestamps;
     }
 
+    protected void setDefaultTags() {
+        getTags().add("audio");
+    }
 }

--- a/src/main/java/app/media/MediaImage.java
+++ b/src/main/java/app/media/MediaImage.java
@@ -6,5 +6,10 @@ public class MediaImage extends FileMedia{
     public MediaImage(String name, double x, double y, double width, double height, byte[] rawData) {
         super(name, x, y, width, height, rawData);
         this.setRawData(rawData);
+
+        getTags().add("image");
+        getTags().add("picture");
+
+        setZindex(2);
     }
 }

--- a/src/main/java/app/media/MediaText.java
+++ b/src/main/java/app/media/MediaText.java
@@ -16,6 +16,7 @@ public class MediaText extends Media {
         super("text-box", x, y, 0, 0);
         this.text = text;
         this.colour = colour;
+        setZindex(-1);
     }
 
     public MediaText(double x, double y) {

--- a/src/main/java/app/media/MediaVideo.java
+++ b/src/main/java/app/media/MediaVideo.java
@@ -15,4 +15,9 @@ public class MediaVideo extends MediaAudio{
                       ArrayList<Duration> timestamps) {
         super(name, x, y, width, height, rawData, timestamps);
     }
+
+    @Override
+    protected void setDefaultTags() {
+        getTags().add("video");
+    }
 }

--- a/src/main/java/app/media/PenStroke.java
+++ b/src/main/java/app/media/PenStroke.java
@@ -29,6 +29,12 @@ public class PenStroke extends Media {
         segments = new ArrayList<>();
         this.thickness = thickness;
         this.colour = colour;
+
+        getTags().add("pen-stroke");
+        getTags().add("stroke");
+        getTags().add("pen");
+
+        setZindex(-2);
     }
 
     public void addSegment(Segment s) {

--- a/src/main/java/app/media/PolygonShape.java
+++ b/src/main/java/app/media/PolygonShape.java
@@ -37,6 +37,7 @@ public class PolygonShape extends GenericShape {
         this.radius = radius;
         this.startAngle = startAngle;
         this.sideCount = sideCount;
+        getTags().add("polygon");
     }
 
     /**

--- a/src/main/java/app/media/RectangleShape.java
+++ b/src/main/java/app/media/RectangleShape.java
@@ -14,6 +14,7 @@ public class RectangleShape extends GenericShape {
      */
     public RectangleShape(Point2D p1, Point2D p2, String colour) {
         super("Rectangle", p1, p2, colour);
+        getTags().add("rectangle");
     }
 
     /**

--- a/src/main/java/gui/media/GUIHyperlinkBox.java
+++ b/src/main/java/gui/media/GUIHyperlinkBox.java
@@ -1,4 +1,5 @@
 package gui.media;
+import app.media.Media;
 import app.media.Hyperlink;
 import javafx.geometry.Point2D;
 import javafx.scene.paint.Color;
@@ -32,7 +33,16 @@ public class GUIHyperlinkBox extends GUIMedia<Hyperlink> {
 
     public GUIHyperlinkBox(Hyperlink media) {
         super(media);
+        setInitialValues();
         mediaUpdated(media);
+    }
+
+    @Override
+    public void mediaUpdated(Media media) {
+        Hyperlink hyperlink = (Hyperlink) media;
+        this.colour = Color.valueOf(hyperlink.getColour());
+        setText(hyperlink.getText());
+        setLink(hyperlink.getLink());
     }
 
     public String getLink(){
@@ -58,7 +68,6 @@ public class GUIHyperlinkBox extends GUIMedia<Hyperlink> {
 
     protected void setLink(String linkIn) {
         this.link = linkIn;
-        this.getMedia().setText(linkIn);
     }
     public String getText() { return this.text.getText(); }
 

--- a/src/main/java/gui/media/GUIMediaFactory.java
+++ b/src/main/java/gui/media/GUIMediaFactory.java
@@ -31,8 +31,8 @@ public class GUIMediaFactory {
         } else if (media instanceof GenericShape) {
             return GUIShapeFactory.getFor((GenericShape) media);
         } else if (media instanceof MediaText) {
-            // Text Box
             if (media instanceof Hyperlink) {
+                // Hyperlink Text Box
                 return new GUIHyperlinkBox((Hyperlink) media);
             } else {
                 // Plain Text Box


### PR DESCRIPTION
Add default z-indices to media so that pen and text will be on top of images/videos, etc.

Also add default tags to each type of media so they can be found more easily using the search tool.

Also included a fix for hyperlinks not loading properly from a file. Something must have gotten messed up while merging stuff together.